### PR TITLE
Fix security issue

### DIFF
--- a/README
+++ b/README
@@ -18,6 +18,7 @@ Test! (Watch the syslog for authentication attempts)
 
 Changelog:
 
+- 04/Nov/2016: v0.4 Fix security fail (reported by Pat Hennessy)
 - 26/Jan/2012: v0.3 Configuration file support added
 - 25/Jan/2012: v0.2 CAS full user+pass combo login, and serviceValidate implemented
 - 25/Jan/2012: v0.1 Initial code

--- a/pam_cas.c
+++ b/pam_cas.c
@@ -72,6 +72,7 @@ int pam_sm_authenticate(pam_handle_t *pamhandle, int flags, int arg, const char 
                 return PAM_AUTH_ERR;
         }
 
+	ret = 0;
 	CAS_init(&cas, c.CAS_BASE_URL, c.SERVICE_URL, c.SERVICE_CALLBACK_URL);
 
 	if (c.ENABLE_ST && strncmp(pw, "ST-", 3) == 0 && strlen(pw) > MIN_TICKET_LEN) { // Possibly serviceTicket?


### PR DESCRIPTION
When username+password authentication is disabled, the module fails to reject invalid tickets, allowing anyone to log in with trivially crafted tickets.

Reported by Pat Hennessy on GitHub (pathennessy)

Fixes #4